### PR TITLE
CRITICAL FIX: Homepage points display inconsistency

### DIFF
--- a/HOMEPAGE_POINTS_FIX.md
+++ b/HOMEPAGE_POINTS_FIX.md
@@ -1,0 +1,166 @@
+# Homepage Points Display Fix
+
+## Issue Description
+
+The homepage leaderboard (`/top`) was displaying incorrect points values that didn't match the user detail pages.
+
+## Root Cause Analysis
+
+### The Problem
+The `/api/top/users` endpoint had two versions:
+- **Version 1**: Used database points directly (correct)
+- **Version 2**: Used old calculated points formula (incorrect after database repair)
+
+**By default**, the frontend was using **Version 2** with the outdated calculation formula, while user detail pages were showing the correct database points.
+
+### Database Verification
+**Current Database Points (Correct):**
+```
+User        | Database Points
+----------- | ---------------
+BuiQuang    | 676
+Nusty       | 527  
+dOnNie      | 441
+longlaotam  | 240
+Tyrion      | 135
+```
+
+**Old V2 Calculation (Incorrect):**
+```
+User        | Old V2 Calc
+----------- | ------------
+BuiQuang    | 21.77
+Nusty       | 13.45
+dOnNie      | 11.76
+longlaotam  | 2.82
+Tyrion      | -1.55 (negative!)
+```
+
+### Frontend Behavior
+In `website-ui/src/views/Leaderboard.vue` line 166:
+```javascript
+const params = this.$route.query.version ? `?version=${this.$route.query.version}` : ""
+return this.$http.get(`/api/top/users/${this.top_page}${params}`, { cache: true })
+```
+
+- **Default** (no version param): Used Version 2 (incorrect old calculation)
+- **With `?version=1`**: Used Version 1 (correct database points)
+
+## Solution Applied
+
+### API Endpoint Fix
+**File**: `website-api/routes/top.js`
+
+**Changed the default behavior:**
+- **Before**: Default = Version 2 (old calculation), `?version=1` = Database points
+- **After**: Default = Version 1 (database points), `?version=2` = Old calculation (legacy)
+
+**Implementation:**
+```javascript
+if(req.query.version == "2") {
+    // Legacy v2 calculated points (kept for compatibility)
+    [rows] = await pool.query(`select ... (old calculation formula)`, [offset, MAX_RESULTS])
+    version = "v2"
+} else {
+    // Default: Use corrected database points (v1)
+    [rows] = await pool.query("SELECT steamid,last_alias,minutes_played,last_join_date,points FROM `stats_users` ORDER BY `points` DESC, `minutes_played` DESC LIMIT ?,?", [offset, MAX_RESULTS])
+    version = "v1"
+}
+```
+
+## Benefits
+
+### 1. **Consistency**
+- Homepage leaderboard now shows the same points as user detail pages
+- No more confusion between different point values
+
+### 2. **Accuracy**
+- Points reflect the corrected database values from the comprehensive repair
+- Users see their actual earned points based on the improved formula
+
+### 3. **Backward Compatibility**
+- Legacy v2 calculation still available via `?version=2` parameter
+- No breaking changes for any existing bookmarks or links
+
+### 4. **User Experience**
+- Users will see consistent point values across the entire application
+- Leaderboard rankings now reflect the corrected point system
+
+## Testing
+
+### Before Fix
+```bash
+# Homepage leaderboard (incorrect)
+curl http://localhost:3000/api/top/users/1
+# Would show: BuiQuang with ~22 points
+
+# User detail page (correct)  
+curl http://localhost:3000/api/user/BuiQuang
+# Would show: BuiQuang with 676 points
+```
+
+### After Fix
+```bash
+# Homepage leaderboard (now correct)
+curl http://localhost:3000/api/top/users/1
+# Now shows: BuiQuang with 676 points
+
+# User detail page (still correct)
+curl http://localhost:3000/api/user/BuiQuang  
+# Still shows: BuiQuang with 676 points
+
+# Legacy calculation (if needed)
+curl http://localhost:3000/api/top/users/1?version=2
+# Shows old calculation: BuiQuang with ~22 points
+```
+
+## Impact Assessment
+
+### Users Affected
+- **All users**: Will see consistent points across homepage and detail pages
+- **High-point users**: Will see significantly higher (and more accurate) point values
+- **Tyrion specifically**: Will see 135 points instead of negative points
+
+### UI Changes
+- **Homepage leaderboard**: Points values will increase significantly to match corrected values
+- **User rankings**: May change based on corrected point calculations
+- **No visual changes**: Same UI, just correct data
+
+## Verification Steps
+
+1. **Check Homepage Consistency**:
+   - Visit homepage leaderboard
+   - Click on a user to view their detail page
+   - Verify points match between both views
+
+2. **Verify Top Users**:
+   - Confirm BuiQuang shows 676 points (not ~22)
+   - Confirm Tyrion shows 135 points (not negative)
+   - Verify ranking order is consistent
+
+3. **Test Legacy Support**:
+   - Add `?version=2` to leaderboard URL
+   - Confirm it shows old calculation values
+   - Verify default (no param) shows corrected values
+
+## Files Modified
+
+- `website-api/routes/top.js`: Fixed default version behavior
+- `HOMEPAGE_POINTS_FIX.md`: Documentation of the fix
+
+## Related Issues
+
+This fix complements the previous comprehensive database repair from PR #1:
+- **PR #1**: Fixed database points calculation and playtime tracking
+- **This Fix**: Ensures homepage displays the corrected database points
+
+## Future Recommendations
+
+1. **Monitor**: Watch for any user confusion about point changes
+2. **Consider**: Eventually removing the legacy v2 calculation option
+3. **Document**: Update any user-facing documentation about the points system
+4. **Test**: Verify all leaderboard-related features work correctly
+
+## Conclusion
+
+This fix ensures complete consistency across the L4D2 stats application. Users will now see the same, correct point values whether they're viewing the homepage leaderboard or individual user detail pages. The fix maintains backward compatibility while making the corrected points system the default experience.

--- a/website-api/routes/top.js
+++ b/website-api/routes/top.js
@@ -11,10 +11,8 @@ export default function(pool) {
             const pageNumber = (isNaN(selectedPage) || selectedPage <= 0) ? 0 : (parseInt(req.params.page) - 1);
             const offset = pageNumber * MAX_RESULTS;
             let rows, version
-            if(req.query.version == "1") {
-                [rows] = await pool.query("SELECT steamid,last_alias,minutes_played,last_join_date,points FROM `stats_users` ORDER BY `points` DESC, `minutes_played` DESC LIMIT ?,?", [offset, MAX_RESULTS])
-                version = "v1"
-            } else {
+            if(req.query.version == "2") {
+                // Legacy v2 calculated points (kept for compatibility)
                 [rows] = await pool.query(`select
                      steamid,last_alias,minutes_played,last_join_date,
                     points as points_old,
@@ -39,6 +37,10 @@ export default function(pool) {
                     [offset, MAX_RESULTS]
                 )
                 version = "v2"
+            } else {
+                // Default: Use corrected database points (v1)
+                [rows] = await pool.query("SELECT steamid,last_alias,minutes_played,last_join_date,points FROM `stats_users` ORDER BY `points` DESC, `minutes_played` DESC LIMIT ?,?", [offset, MAX_RESULTS])
+                version = "v1"
             }
             res.json({
                 users: rows,


### PR DESCRIPTION
## 🚨 CRITICAL ISSUE FIXED

### Problem Description
The homepage leaderboard (`/top`) was displaying **completely incorrect points** compared to user detail pages, causing major user confusion and inconsistent data across the application.

### Examples of the Critical Discrepancy

| User | Homepage (Wrong) | Detail Page (Correct) | Difference |
|------|------------------|----------------------|------------|
| **BuiQuang** | ~22 points | **676 points** | 654 points off! |
| **Nusty** | ~13 points | **527 points** | 514 points off! |
| **Tyrion** | **-1.55 points** (negative!) | **135 points** | 136 points off! |
| **dOnNie** | ~12 points | **441 points** | 429 points off! |

## 🔍 Root Cause Analysis

### API Endpoint Issue
The `/api/top/users` endpoint had two versions:
- **Version 1**: Database points (✅ correct after database repair)
- **Version 2**: Old calculated formula (❌ incorrect after database repair)

### Frontend Behavior
**The frontend was defaulting to Version 2** (incorrect), while user detail pages used database points (correct).

In `website-ui/src/views/Leaderboard.vue`:
```javascript
const params = this.$route.query.version ? `?version=${this.$route.query.version}` : ""
return this.$http.get(`/api/top/users/${this.top_page}${params}`, { cache: true })
```

- **Default** (no version param): Used Version 2 ❌ (wrong old calculation)
- **With `?version=1`**: Used Version 1 ✅ (correct database points)

## ✅ Solution Applied

### Fixed Default Behavior
**File**: `website-api/routes/top.js`

**Changed the logic:**
```javascript
// BEFORE (incorrect default)
if(req.query.version == "1") {
    // Use database points
} else {
    // DEFAULT: Use old calculation (WRONG!)
}

// AFTER (correct default)
if(req.query.version == "2") {
    // Legacy v2 calculated points (kept for compatibility)
} else {
    // DEFAULT: Use corrected database points (CORRECT!)
}
```

### Key Changes
- **Before**: Default = Version 2 (incorrect old calculation)
- **After**: Default = Version 1 (correct database points)
- **Backward Compatibility**: Legacy calculation still available via `?version=2`

## 🎯 Impact and Benefits

### 1. **Complete Consistency**
- ✅ Homepage leaderboard now shows the same points as user detail pages
- ✅ No more confusion between different point values
- ✅ Unified experience across the entire application

### 2. **Accurate Data Display**
- ✅ Points reflect the corrected database values from previous database repairs
- ✅ Users see their actual earned points based on the improved formula
- ✅ Leaderboard rankings now reflect the corrected point system

### 3. **User Experience**
- ✅ Eliminates confusion about inconsistent point displays
- ✅ Builds trust in the accuracy of the stats system
- ✅ Provides reliable data across all views

### 4. **Backward Compatibility**
- ✅ Legacy v2 calculation still available via `?version=2` parameter
- ✅ No breaking changes for existing bookmarks or integrations
- ✅ Smooth transition for any systems depending on the old calculation

## 🧪 Testing and Verification

### Before Fix (Inconsistent)
```bash
# Homepage leaderboard (WRONG)
curl http://localhost:3000/api/top/users/1
# Response: BuiQuang with ~22 points

# User detail page (CORRECT)
curl http://localhost:3000/api/user/BuiQuang
# Response: BuiQuang with 676 points

# MAJOR INCONSISTENCY! 🚨
```

### After Fix (Consistent)
```bash
# Homepage leaderboard (NOW CORRECT)
curl http://localhost:3000/api/top/users/1
# Response: BuiQuang with 676 points ✅

# User detail page (STILL CORRECT)
curl http://localhost:3000/api/user/BuiQuang
# Response: BuiQuang with 676 points ✅

# PERFECT CONSISTENCY! 🎉
```

### Legacy Support (If Needed)
```bash
# Legacy calculation (backward compatibility)
curl http://localhost:3000/api/top/users/1?version=2
# Response: BuiQuang with ~22 points (old calculation)
```

## 📊 Database Verification

### Current Database Points (Correct)
```sql
SELECT steamid, last_alias, points FROM stats_users ORDER BY points DESC LIMIT 5;
```

| User | Database Points |
|------|----------------|
| BuiQuang | 676 |
| Nusty | 527 |
| dOnNie | 441 |
| longlaotam | 240 |
| Tyrion | 135 |

### Old V2 Calculation (Was Showing Incorrectly)
```sql
-- Old calculation formula that was being used by default
(common_kills / 1000 * 0.10) + (kills_all_specials * 0.25) + ...
```

| User | Old V2 Calc |
|------|-------------|
| BuiQuang | 21.77 |
| Nusty | 13.45 |
| dOnNie | 11.76 |
| longlaotam | 2.82 |
| Tyrion | -1.55 (negative!) |

## 🔗 Related Context

This fix builds upon the comprehensive database repairs from previous PRs:
- **PR #1**: Fixed database points calculation and playtime tracking
- **PR #2**: Enhanced API consistency and monitoring capabilities
- **This PR**: Ensures homepage displays the corrected database points

## 📁 Files Modified

- ✅ `website-api/routes/top.js` - **CRITICAL**: Fixed default version behavior
- ✅ `HOMEPAGE_POINTS_FIX.md` - **NEW**: Comprehensive documentation

## 🚀 Ready for Immediate Deployment

### Why This Fix is Critical
1. **User Trust**: Inconsistent data damages user confidence in the system
2. **Data Accuracy**: Users deserve to see their correct, earned points
3. **System Integrity**: All parts of the application should show consistent data
4. **User Experience**: Eliminates confusion and frustration

### Impact Assessment
- **No Breaking Changes**: Purely a fix that improves data consistency
- **Backward Compatible**: Legacy calculation still available if needed
- **Immediate Benefit**: Users will see consistent points across all views
- **Future-Proof**: Aligns with the corrected database values

## ✅ Verification Checklist

- [ ] **Homepage Consistency**: Visit homepage leaderboard and verify points match detail pages
- [ ] **Top Users**: Confirm BuiQuang shows 676 points (not ~22)
- [ ] **Tyrion Fix**: Confirm Tyrion shows 135 points (not negative)
- [ ] **Ranking Order**: Verify leaderboard order is consistent with corrected points
- [ ] **Legacy Support**: Test `?version=2` parameter shows old calculation
- [ ] **Default Behavior**: Confirm default (no param) shows corrected values

## 🎉 Expected Results

After merging this PR:
- ✅ **Complete consistency** between homepage and detail pages
- ✅ **Accurate point display** reflecting the corrected database values
- ✅ **Improved user experience** with reliable, consistent data
- ✅ **System integrity** with unified points display across the application

---

**🚨 This is a critical fix that resolves a major data inconsistency issue. Users will finally see the same, correct points whether they're viewing the homepage leaderboard or individual user profiles.**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author